### PR TITLE
Add README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+```markdown
+# OctoAcme Project Management — README
+
+Welcome — this folder centralizes OctoAcme’s project management playbooks, templates, and runbooks. Use this README as the single entry point to find process guidance, role definitions, and checklists used across project lifecycles.
+
+Summary of Project Management Processes
+- Customer-first & iterative delivery: We prioritize small, testable increments that deliver customer value and allow us to learn quickly.
+- Clear ownership & roles: Each project names a Project Manager (PM) and a Product Lead (PdM); responsibilities are documented so decisions and handoffs are explicit.
+- Core phases & artifacts: Initiation (one-pager), Planning (backlog, DoD, release plan), Execution (project board, PR workflow, CI), Release (deployment checklist, rollback plan), and Retrospective (action items tracked back into the backlog).
+- Risk management & communication: We maintain a risk register, use a single source of truth for status, provide templates for weekly updates and incident communications, and follow defined escalation paths.
+- Continuous improvement & quality: Quality gates include unit/integration tests, smoke tests, security scanning in CI, manual QA where needed, and regular retrospectives that convert learnings into prioritized action items.
+
+Key Workflows (quick reference)
+- Project board workflow: Backlog → Ready → In Progress → In Review → QA → Done
+- Pull Request expectations: small PRs, include issue link + acceptance criteria, CI must pass, require at least one approval
+- Release flow: staging smoke tests → automated production deploy → post-deploy verification → stakeholder announcement
+
+Personas / Roles (who does what)
+- Product Manager (PdM): defines outcomes, success metrics, backlog prioritization.
+- Project Manager (PM): coordinates schedule, risks, dependencies, and communications.
+- Developers: implement, test, and deliver features; participate in design and code review.
+- QA / Testing: validate acceptance criteria and run manual or exploratory testing as needed.
+- Stakeholders & Sponsors: provide input, approvals, and business context.
+
+Communication Cadence
+- Daily standups for the delivery team (15 min) to surface progress & blockers
+- Weekly PM + PdM sync for progress, risks, and decisions
+- Sprint demos / milestone reviews and monthly stakeholder updates
+- Use the project README or release doc as the single source of truth for status
+
+Quality Assurance & Risk Practices
+- Automated tests (unit/integration) and security scans run in CI
+- End-to-end smoke tests for critical flows before release
+- Manual QA for acceptance when required by the feature or risk profile
+- Risk register maintained and reviewed weekly; clear escalation path (Team → PM → Product Lead → Sponsor)
+- Retrospectives after milestones/incidents to create measurable action items
+
+Docs index
+- Project Management Overview — docs/octoacme-project-management-overview.md
+- Project Initiation Guide — docs/octoacme-project-initiation.md
+- Project Planning — docs/octoacme-project-planning.md
+- Execution & Tracking — docs/octoacme-execution-and-tracking.md
+- Risk Management & Communication — docs/octoacme-risks-and-communication.md
+- Release & Deployment Guide — docs/octoacme-release-and-deployment.md
+- Retrospective & Continuous Improvement — docs/octoacme-retrospective-and-continuous-improvement.md
+- Roles & Personas — docs/octoacme-roles-and-personas.md
+
+Contributing / Updating these docs
+- To propose changes, use the process-doc issue template: .github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml
+- For substantive changes, open an issue with the template, discuss with stakeholders as needed, then submit a PR that references the issue.
+- Keep the project README or release doc as the single source of truth for status updates.
+
+If you want, I can also produce a minimal commit patch or run the commands for you if you provide a GitHub token with PR creation permissions. Otherwise, run the commands below to create the PR yourself.
+```


### PR DESCRIPTION
Adds docs/README.md as a central entry point for OctoAcme project management resources and includes a concise summary of workflows, roles, communication cadence, and QA practices. #2 