### PR TITLE
Expand Personas, Add Role Onboarding and Handoff Templates

### DIFF
--- a/docs/octoacme-role-handoff-template.md
+++ b/docs/octoacme-role-handoff-template.md
@@ -1,0 +1,15 @@
+# OctoAcme Role Handoff Template
+
+To transfer responsibilities (temporary or permanent) between roles/personas:
+
+- Handoff Date:
+- Role receiving handoff:
+- Role relinquishing handoff:
+- Checklist:
+  - [ ] All open tasks and risks communicated
+  - [ ] Key contacts/Stakeholders introduced
+  - [ ] Process docs reviewed
+  - [ ] Known blockers/escalations surfaced
+  - [ ] Confirmation from both parties
+
+*Attach as project artifact if handoff involves PM/PdM/Dev, or any critical role.*

--- a/docs/octoacme-role-onboarding-checklist.md
+++ b/docs/octoacme-role-onboarding-checklist.md
@@ -1,0 +1,13 @@
+# OctoAcme Role Onboarding Checklist
+
+Use this checklist to onboard any new project role/persona:
+
+- [ ] Review role summary and key responsibilities in `octoacme-roles-and-personas.md`
+- [ ] Meet with immediate collaborators (PM, PdM, Dev, QA, etc.)
+- [ ] Get access to core repositories, boards, and process docs
+- [ ] Review current project status, backlog, and recent retrospectives
+- [ ] Schedule intro meeting with stakeholders, if applicable
+- [ ] Review relevant process templates and checklists
+- [ ] Identify and surface any gaps in responsibilities or overlaps
+
+*Customize per role as required.*

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -1,13 +1,14 @@
-# OctoAcme Personas
+# OctoAcme Personas & Expanded Roles
 
-This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.
+This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.  
+**Now expanded to include additional personas essential for clarity, accountability, and scaling.**
 
 ---
 
 ## Developers
 
 ### Role Summary
-Developers design, build, test, and deliver software components. They collaborate with product and project leads to implement features that meet acceptance criteria and quality standards.
+Design, build, test, and deliver software components. Collaborate with product and project leads to implement features that meet acceptance criteria and quality standards.
 
 ### Responsibilities
 - Implement features and fixes to meet acceptance criteria
@@ -31,7 +32,7 @@ Developers design, build, test, and deliver software components. They collaborat
 ## Product Managers
 
 ### Role Summary
-Product Managers define what should be built to deliver customer and business value. They own the product vision, prioritize the backlog, and measure outcomes.
+Define what should be built to deliver customer and business value; own the product vision, prioritize the backlog, and measure outcomes.
 
 ### Responsibilities
 - Define problem statements and success metrics
@@ -54,7 +55,7 @@ Product Managers define what should be built to deliver customer and business va
 ## Project Managers
 
 ### Role Summary
-Project Managers coordinate delivery activities, manage schedules, risks, and communications. They enable the team to deliver on commitments efficiently.
+Coordinate delivery activities, manage schedules, risks, and communications; enable the team to deliver on commitments efficiently.
 
 ### Responsibilities
 - Create and maintain project plans and timelines
@@ -75,7 +76,115 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
-## How these personas are used in the exercise
-- Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
-- Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
+## Scrum Master
 
+**Role Summary:**  
+Facilitates agile ceremonies, supports team improvement, and removes blockers.
+
+**Responsibilities:**  
+- Run standups, retrospectives, planning
+- Identify and eliminate process bottlenecks
+- Coach teams on agile principles
+- Escalate blockers and coordinate with PM
+
+**Interactions:**  
+Works with Project Manager for delivery, Developers for team health, and Product Manager for backlog clarity.
+
+---
+
+## UX Designer
+
+**Role Summary:**  
+Shapes user flows, designs prototypes, and validates usability.
+
+**Responsibilities:**  
+- Conduct user research and usability testing
+- Design wireframes and prototypes
+- Flag UX risks/issues early
+
+**Interactions:**  
+Works with Product Manager and Developers, surfaces usability issues to PM, advocates for customer-centric design.
+
+---
+
+## Security Lead
+
+**Role Summary:**  
+Ensures security requirements are defined, implemented, and reviewed.
+
+**Responsibilities:**  
+- Analyze new features for security impact
+- Translate risks to mitigation plans
+- Lead incident response if needed
+
+**Interactions:**  
+Supports Project Manager in risk register, works with Developers on secure coding, consults with stakeholders.
+
+---
+
+## Release Manager
+
+**Role Summary:**  
+Owns release and deployment coordination across teams.
+
+**Responsibilities:**  
+- Prepare release plans, checklists, and windows
+- Communicate deployment status and incidents
+- Coordinate rollbacks and incident playbooks
+
+**Interactions:**  
+Syncs with QA/Testing, Project Manager, and Developers. Keeps stakeholders updated on release progress.
+
+---
+
+## Business Analyst
+
+**Role Summary:**  
+Maps business requirements to functional specs, clarifies scope.
+
+**Responsibilities:**  
+- Gather and analyze requirements
+- Document user stories, flows, and acceptance criteria
+- Propose enhancements
+
+**Interactions:**  
+Bridges Stakeholders, Product Manager, and Developers. Surfaces gaps to PM.
+
+---
+
+## Support Specialist
+
+**Role Summary:**  
+Handles support requests, patterns recurring issues, and closes feedback loop.
+
+**Responsibilities:**  
+- Track and escalate support trends
+- Triage customer reports
+- Coordinate fixes and communicate outcomes
+
+**Interactions:**  
+Works with Product/Project Manager, Developers, and users to resolve issues and surface product gaps.
+
+---
+
+## Technical Writer
+
+**Role Summary:**  
+Creates, updates, and maintains all project documentation.
+
+**Responsibilities:**  
+- Write onboarding guides, API docs, process docs
+- Review and edit for clarity and structure
+- Ensure living documentation
+
+**Interactions:**  
+Collaborates closely with Developers, Product Manager, and PM to maintain accuracy.
+
+---
+
+# How these personas are used
+- Use these expanded personas to clarify responsibilities, enable onboarding, and improve cross-role handoffs.
+
+# Updates
+Expanded with Scrum Master, UX Designer, Security Lead, Release Manager, Business Analyst, Support Specialist, Technical Writer to close gaps and clarify interactions.
+All teams should reference these roles during planning, execution, and retrospectives.


### PR DESCRIPTION
Implements new and expanded personas in octoacme-roles-and-personas.md.
Adds onboarding and handoff templates based on gaps identified in issue #4.
All changes go in the docs/ directory. #4 